### PR TITLE
No global vars

### DIFF
--- a/cov.el
+++ b/cov.el
@@ -87,7 +87,6 @@
 
 (defun gcov-set-overlays ()
   (interactive)
-  (gcov-clear-overlays)
   (let* ((lines (mapcar 'gcov-parse (gcov-read (buffer-file-name))))
          (max (gcov-l-max (mapcar 'gcov-second lines))))
     (while (< 0 (list-length lines))

--- a/cov.el
+++ b/cov.el
@@ -61,44 +61,39 @@
 
 (defun gcov-make-overlay (line fringe)
   "Create an overlay for the line"
-  (setq ol-front-mark
-        (save-excursion
-          (goto-line line)
-          (point-marker)))
-  (setq ol-back-mark
-        (save-excursion
-          (goto-line line)
-          (end-of-line)
-          (point-marker)))
-  (setq ol (make-overlay ol-front-mark ol-back-mark))
-  (overlay-put ol 'before-string fringe)
-  ol)
+  (let* ((ol-front-mark
+          (save-excursion
+            (goto-line line)
+            (point-marker)))
+         (ol-back-mark
+          (save-excursion
+            (goto-line line)
+            (end-of-line)
+            (point-marker)))
+         (ol (make-overlay ol-front-mark ol-back-mark)))
+    (overlay-put ol 'before-string fringe)
+    ol))
 
 (defun gcov-get-fringe (n max)
-  (setq face
-        (cond ((< gcov-high-threshold (/ n (float max)))
-               'gcov-heavy-face)
-              ((< gcov-med-threshold (/ n (float max)))
-               'gcov-med-face)
-              ((< n 1)
-               'gcov-none-face)
-              (t 'gcov-light-face)))
-  (propertize "f" 'display `(left-fringe empty-line ,face)))
-
-(gcov-get-fringe 29 30)
-(> gcov-high-threshold (/ 28 (float 30)))
+  (let ((face
+         (cond ((< gcov-high-threshold (/ n (float max)))
+                'gcov-heavy-face)
+               ((< gcov-med-threshold (/ n (float max)))
+                'gcov-med-face)
+               ((< n 1)
+                'gcov-none-face)
+               (t 'gcov-light-face))))
+    (propertize "f" 'display `(left-fringe empty-line ,face))))
 
 (defun gcov-set-overlays ()
   (interactive)
-  (clear-overlays)
-  (setq lines (mapcar 'gcov-parse (gcov-read (buffer-file-name))))
-  (setq max (gcov-l-max (mapcar 'gcov-second lines)))
-  (print max)
-  (while (< 0 (list-length lines))
-    (setq line (pop lines))
-    (setq overlay (gcov-make-overlay (first line) (gcov-get-fringe (gcov-second line) max)))
-    (setq gcov-overlays (cons overlay gcov-overlays)))
-  (list-length lines))
+  (gcov-clear-overlays)
+  (let* ((lines (mapcar 'gcov-parse (gcov-read (buffer-file-name))))
+         (max (gcov-l-max (mapcar 'gcov-second lines))))
+    (while (< 0 (list-length lines))
+      (let* ((line (pop lines))
+             (overlay (gcov-make-overlay (first line) (gcov-get-fringe (gcov-second line) max))))
+        (setq gcov-overlays (cons overlay gcov-overlays))))))
 
 (defun gcov-clear-overlays ()
   (interactive)

--- a/test/test
+++ b/test/test
@@ -1,0 +1,11 @@
+comment line
+
+a line executed 100%
+a line executed  86%
+a line executed  85%
+a line executed  84%
+a line executed  46%
+a line executed  45%
+a line executed  44%
+a line executed   1%
+a line never executed

--- a/test/test.gcov
+++ b/test/test.gcov
@@ -1,0 +1,16 @@
+        -:    0:Source:test
+        -:    0:Graph:test.gcno
+        -:    0:Data:test.gcda
+        -:    0:Runs:100
+        -:    0:Programs:1
+        -:    1:comment line
+        -:    2:
+      100:    3:a line executed 100%
+       86:    4:a line executed  86%
+       85:    5:a line executed  85%
+       84:    6:a line executed  84%
+       46:    7:a line executed  46%
+       45:    8:a line executed  45%
+       44:    9:a line executed  44%
+        1:   10:a line executed   1%
+    #####:   11:a line never executed


### PR DESCRIPTION
This time I eliminated some generated global variables.

I also removed `clear-overlays`  from `gcov-set-overlays` since this was wrong and is not needed with `gcov-update`.

Third thing is adding a oversimplified test coverage file.
