### PR TITLE
Improved regexp and help-echo

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,7 +3,6 @@
 
 (package-file "cov.el")
 
-(depends-on "s")
 (depends-on "f")
 
 (development

--- a/cov.el
+++ b/cov.el
@@ -39,10 +39,10 @@
   "The group for everything in cov.el")
 
 (defun gcov-l-max (list)
-  (eval (cons 'max list)))
+  (eval (cons 'max (cons 0 list))))
 
 (defun gcov-second (list)
-  (nth 1 list))
+  (nth 1 list))()
 
 (defgroup gcov-faces nil
   "Faces for gcov."

--- a/cov.el
+++ b/cov.el
@@ -201,12 +201,13 @@ If `gcov-coverage-file' is non nil, the value of that variable is returned. Othe
   (interactive)
   (let ((gcov (gcov--coverage)))
     (if gcov
-        (save-match-data
-          (let* ((lines (mapcar 'gcov--parse (gcov--read (car gcov))))
-                 (max (gcov-l-max (mapcar 'gcov-second lines))))
-            (while (< 0 (list-length lines))
-              (let ((line (pop lines)))
-                (gcov--set-overlay line max)))))
+        (let (lines max)
+          (save-match-data
+            (setq lines (mapcar 'gcov--parse (gcov--read (car gcov)))))
+          (setq max (gcov-l-max (mapcar 'gcov-second lines)))
+          (while (< 0 (list-length lines))
+            (let ((line (pop lines)))
+              (gcov--set-overlay line max))))
       (message "No coverage data found."))))
 
 (defun gcov-clear-overlays ()

--- a/cov.el
+++ b/cov.el
@@ -195,17 +195,18 @@ If `gcov-coverage-file' is non nil, the value of that variable is returned. Othe
   (interactive)
   (let ((gcov (gcov--coverage)))
     (if gcov
-        (let* ((lines (mapcar 'gcov--parse (gcov--read (car gcov))))
-               (max (gcov-l-max (mapcar 'gcov-second lines))))
-          (while (< 0 (list-length lines))
-            (let* ((line (pop lines))
-                   (n (gcov-second line))
-                   (percentage (/ n (float max)))
-                   (overlay (gcov-make-overlay
-                             (first line)
-                             (gcov--get-fringe n max percentage)
-                             (gcov--help n max percentage))))
-              (setq gcov-overlays (cons overlay gcov-overlays)))))
+        (save-match-data
+          (let* ((lines (mapcar 'gcov--parse (gcov--read (car gcov))))
+                 (max (gcov-l-max (mapcar 'gcov-second lines))))
+            (while (< 0 (list-length lines))
+              (let* ((line (pop lines))
+                     (n (gcov-second line))
+                     (percentage (/ n (float max)))
+                     (overlay (gcov-make-overlay
+                               (first line)
+                               (gcov--get-fringe n max percentage)
+                               (gcov--help n max percentage))))
+                (setq gcov-overlays (cons overlay gcov-overlays))))))
       (message "No coverage data found."))))
 
 (defun gcov-clear-overlays ()

--- a/cov.el
+++ b/cov.el
@@ -10,7 +10,7 @@
 ;; Keywords: coverage
 ;; Homepage: https://github.com/AdamNiederer/cov
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "24.4") (s "1.11.0") (f "0.18.2"))
+;; Package-Requires: ((emacs "24.4") (f "0.18.2"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -214,6 +214,14 @@ If `gcov-coverage-file' is non nil, the value of that variable is returned. Othe
   (interactive)
   (while (< 0 (list-length gcov-overlays))
     (delete-overlay (pop gcov-overlays))))
+
+(defun gcov-visit-coverage-file ()
+  "Visit coverage file."
+  (interactive)
+  (let ((gcov (gcov--coverage)))
+    (if gcov
+        (find-file (car gcov))
+      (message "No coverage data found."))))
 
 (defun gcov-update ()
   "Turn on gcov-mode."

--- a/cov.el
+++ b/cov.el
@@ -145,9 +145,6 @@ If `gcov-coverage-file' is non nil, the value of that variable is returned. Othe
       (setq gcov-coverage-file (gcov--locate-coverage (f-this-file)))))
 
 (defun gcov--keep-line? (line)
-  (s-matches? "\\s-+[0-9#]+:\\s-+[0-9#]+:" (s-left 16 line)))
-
-(defun gcov--keep-line? (line)
   (string-match "^\\s-+\\([0-9#]+\\):\\s-+\\([0-9#]+\\):" line))
 
 (defun gcov--read (file-path)

--- a/cov.el
+++ b/cov.el
@@ -188,6 +188,15 @@ If `gcov-coverage-file' is non nil, the value of that variable is returned. Othe
 (defun gcov--help (n max percentage)
   (format "gcov: executed %s times (~%s%%)" n (* percentage 100)))
 
+(defun gcov--set-overlay (line max)
+  (let* ((n (gcov-second line))
+         (percentage (/ n (float max)))
+         (overlay (gcov-make-overlay
+                   (first line)
+                   (gcov--get-fringe n max percentage)
+                   (gcov--help n max percentage))))
+    (setq gcov-overlays (cons overlay gcov-overlays))))
+
 (defun gcov-set-overlays ()
   (interactive)
   (let ((gcov (gcov--coverage)))
@@ -196,14 +205,8 @@ If `gcov-coverage-file' is non nil, the value of that variable is returned. Othe
           (let* ((lines (mapcar 'gcov--parse (gcov--read (car gcov))))
                  (max (gcov-l-max (mapcar 'gcov-second lines))))
             (while (< 0 (list-length lines))
-              (let* ((line (pop lines))
-                     (n (gcov-second line))
-                     (percentage (/ n (float max)))
-                     (overlay (gcov-make-overlay
-                               (first line)
-                               (gcov--get-fringe n max percentage)
-                               (gcov--help n max percentage))))
-                (setq gcov-overlays (cons overlay gcov-overlays))))))
+              (let ((line (pop lines)))
+                (gcov--set-overlay line max)))))
       (message "No coverage data found."))))
 
 (defun gcov-clear-overlays ()

--- a/test/cov-test.el
+++ b/test/cov-test.el
@@ -2,6 +2,25 @@
 
 (require 'cov)
 
+;; gcov--keep-line?
+(ert-deftest gcov--keep-line--test ()
+  (should-not (gcov--keep-line? "        -:   22:        ")))
+
+(ert-deftest gcov--keep-line--block-test ()
+  (should-not (gcov--keep-line? "        1:   21-block  0")))
+
+(ert-deftest gcov--keep-line--executed-test ()
+  (let ((line "        6:   24:        "))
+    (should (gcov--keep-line? line))
+    (should (equal (match-string 1 line) "6"))
+    (should (equal (match-string 2 line) "24"))))
+
+(ert-deftest gcov--keep-line--not-executed-test ()
+  (let ((line "    #####:   24:        "))
+    (should (gcov--keep-line? line))
+    (should (equal (match-string 1 line) "#####"))
+    (should (equal (match-string 2 line) "24"))))
+
 ;; gcov--locate-coverage-postfix
 (ert-deftest gcov--locate-coverage-postfix-test ()
   (let* ((path test-path)

--- a/test/test.gcov
+++ b/test/test.gcov
@@ -6,6 +6,7 @@
         -:    1:comment line
         -:    2:
       100:    3:a line executed 100%
+        1:    3-block  0
        86:    4:a line executed  86%
        85:    5:a line executed  85%
        84:    6:a line executed  84%


### PR DESCRIPTION
I probably start generating work on your side...

I now improved the regexp thus that gcov lines for branches are not taken as "executed" lines.

I also added a help-echo to the overlay. Thats primarily for development purposes, thus that I can inspect what cov.el used to colorize the fringe. However, I am not really happy with that, would like to have the option to show the number between fringe and source code (which I know how to do, but not covered lines will be misaligned...).

Btw, I have yet a couple of requirements (ideas) that I would like to see being fulfilled, but which would take a while to implement. Is it ok to file them as issues? So we can discuss them?