### PR TITLE
Load and process coverage file in buffer

### DIFF
--- a/cov.el
+++ b/cov.el
@@ -194,7 +194,7 @@ If `cov-coverage-file' is non nil, the value of that variable is returned. Other
   "Create an overlay for the line"
   (let (ol-front-mark ol-back-mark ol)
     (save-excursion
-      (goto-line line)
+      (goto-char (point-min)) (forward-line (1- line))
       (setq ol-front-mark (point))
       (end-of-line)
       (setq ol-back-mark (point)))

--- a/cov.el
+++ b/cov.el
@@ -192,13 +192,15 @@ If `cov-coverage-file' is non nil, the value of that variable is returned. Other
 
 (defun cov--make-overlay (line fringe help)
   "Create an overlay for the line"
-  (let* ((ol-front-mark
-          (save-excursion
-            (goto-line line)
-            (point)))
-         (ol (make-overlay ol-front-mark ol-front-mark)))
+  (let (ol-front-mark ol-back-mark ol)
+    (save-excursion
+      (goto-line line)
+      (setq ol-front-mark (point))
+      (end-of-line)
+      (setq ol-back-mark (point)))
+    (setq ol (make-overlay ol-front-mark ol-back-mark))
     (overlay-put ol 'before-string fringe)
-    ;(overlay-put ol 'help-echo help)
+    (overlay-put ol 'help-echo help)
     ol))
 
 (defun cov--get-face (percentage)
@@ -222,7 +224,7 @@ code's execution frequency"
   (propertize "f" 'display `(left-fringe empty-line ,(cov--get-face percentage))))
 
 (defun cov--help (n percentage)
-  (format "gcov: executed %s times (~%s%%)" n (* percentage 100)))
+  (format "cov: executed %d times (~%.2f%% of highest)" n (* percentage 100)))
 
 (defun cov--set-overlay (line max)
   (let* ((times-executed (nth 1 line))

--- a/cov.el
+++ b/cov.el
@@ -194,7 +194,8 @@ If `cov-coverage-file' is non nil, the value of that variable is returned. Other
   "Create an overlay for the line"
   (let (ol-front-mark ol-back-mark ol)
     (save-excursion
-      (goto-char (point-min)) (forward-line (1- line))
+      (goto-char (point-min))
+      (forward-line (1- line))
       (setq ol-front-mark (point))
       (end-of-line)
       (setq ol-back-mark (point)))
@@ -226,11 +227,11 @@ code's execution frequency"
 (defun cov--help (n percentage)
   (format "cov: executed %d times (~%.2f%% of highest)" n (* percentage 100)))
 
-(defun cov--set-overlay (line max)
-  (let* ((times-executed (nth 1 line))
+(defun cov--set-overlay (line-data max)
+  (let* ((times-executed (cl-second line-data))
          (percentage (/ times-executed (float max)))
          (overlay (cov--make-overlay
-                   (cl-first line)
+                   (cl-first line-data)
                    (cov--get-fringe percentage)
                    (cov--help times-executed percentage))))
     (push overlay cov-overlays)))

--- a/cov.el
+++ b/cov.el
@@ -150,7 +150,7 @@ If `gcov-coverage-file' is non nil, the value of that variable is returned. Othe
           (save-match-data
             (while more
               (beginning-of-line)
-              (when (looking-at "^\\s-+\\(\\([0-9#]+\\):\\s-+\\([0-9#]+\\)\\):")
+              (when (looking-at "^\\s-+\\(\\([0-9#]+\\):\\s-+\\([0-9]+\\)\\):")
                 (push (list (string-to-number (match-string-no-properties 3))
                             (string-to-number (match-string-no-properties 2))
                             (match-string-no-properties 1))

--- a/test/cov-test.el
+++ b/test/cov-test.el
@@ -6,6 +6,7 @@
 (ert-deftest cov--parse--hyphen-test ()
   (with-temp-buffer
     (insert "        -:   22:        ")
+    (goto-char 1)
     (should (equal
              (cov--parse (current-buffer))
              '()))))
@@ -13,6 +14,7 @@
 (ert-deftest cov--parse--block-test ()
   (with-temp-buffer
     (insert "        1:   21-block  0")
+    (goto-char 1)
     (should (equal
              (cov--parse (current-buffer))
              '()))))
@@ -20,6 +22,7 @@
 (ert-deftest cov--parse--executed-test ()
   (with-temp-buffer
     (insert "        6:   24:        ")
+    (goto-char 1)
     (should (equal
              (cov--parse (current-buffer))
              '((24 6))))))
@@ -27,6 +30,7 @@
 (ert-deftest cov--parse--big-value-test ()
   (with-temp-buffer
     (insert "999999999:99999:        ")
+    (goto-char 1)
     (should (equal
              (cov--parse (current-buffer))
              '((99999 999999999))))))
@@ -34,6 +38,7 @@
 (ert-deftest cov--parse--multiline-test ()
   (with-temp-buffer
     (insert "        6:    1:\n       16:    2:\n       66:    3:")
+    (goto-char 1)
     (should (equal
              (cov--parse (current-buffer))
              '((3 66) (2 16) (1 6))))))
@@ -41,6 +46,7 @@
 (ert-deftest cov--parse--not-executed-test ()
   (with-temp-buffer
     (insert "    #####:   24:        ")
+    (goto-char 1)
     (should (equal
              (cov--parse (current-buffer))
              '((24 0))))))


### PR DESCRIPTION
I changed the parsing such that is does not process a filtered list of line strings but rather operates on the coverage file directly.

This may give a little less performance, but works also on very large coverage files. I did this, because:
- This may offer the ability to once provide "lazy highlighting" in the future.
- Keeping the buffer may provide the option to intercept auto-revert and automatically update on changes in the coverage file.
- The other solution failed strangely with an error on large data sets. I did not investigate the source, because emacs was unusable with a huge back-trace.
