### PR TITLE
Better multifile coverage handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ a new format:
 1. Add a function to `cov-coverage-file-paths` that locates a coverage
    file for a given file. If a coverage file is found, it should
    return a cons of the coverage file path and an identifier, like
-   `(cons filepath 'mytool)`
+   `(cons filepath 'mytool)`. The original name of the file can be
+   found in the `cov-coverage-file` buffer local variable.
 2. Implement a `cov--mytool-parse`. The parse function is called with
    a temp buffer with the coverage file data as `(current-buffer)` and
    should parse the data and return the coverage as a alist of files

--- a/README.md
+++ b/README.md
@@ -3,48 +3,79 @@
 [![MELPA](http://melpa.org/packages/cov-badge.svg)](http://melpa.org/#/cov)
 
 # cov
-`cov` shows code coverage data for your program in emacs. Currently, it supports gcov and lcov output.
+`cov` shows code coverage data for your program in emacs. Currently,
+it supports gcov and lcov output, as well as the Coveralls format
+produced by [undercover.el](https://github.com/sviridov/undercover.el).
 ![Screenshot](example.png)
 
 ## Installation
 cov is on MELPA. To install it, type `M-x package-install RET cov RET`
 
 ## Usage
-`set-overlays` and `clear-overlays` will add and remove the data overlays. Proper namespacing and a mode are to be implemented.
-This program assumes you have a standard gcov file for your current buffer. For example, if your current buffer is `/whatever/strings.c`, `cov` assumes there's a file called `/whatever/strings.c.gcov`
+Enable `cov-mode` in a buffer. It looks for a file with the same name
+as the buffer file with the suffix '.gcov', or a `coverage-final.json`
+file, in the same directory.
 
 ## Customization
-By default, cov will run in profiling mode. Lines which are executed a lot will be decorated with `cov-heavy-face`,
-while lines executed less will be decorated with `cov-med-face` and `cov-light-face`. Lines not executed at all will
-be decorated with `cov-none-face`.
+By default, cov will run in profiling mode. Lines which are executed a
+lot will be decorated with `cov-heavy-face`, while lines executed less
+will be decorated with `cov-med-face` and `cov-light-face`. Lines not
+executed at all will be decorated with `cov-none-face`.
 
-Setting `cov-coverage-mode` to `t` will run cov in coverage mode. In this mode, if a line is run, `cov-coverage-run-face`
-will be applied to the line, while `cov-coverage-not-run-face` will be applied to lines which were not run. Coverage mode
-should make finding uncovered lines slightly easier than profiling mode.
+Setting `cov-coverage-mode` to `t` will run cov in coverage mode. In
+this mode, if a line is run, `cov-coverage-run-face` will be applied
+to the line, while `cov-coverage-not-run-face` will be applied to
+lines which were not run. Coverage mode should make finding uncovered
+lines slightly easier than profiling mode.
 
-- `cov-high-threshold` - If a line is run more than (`cov-high-threshold` * 100) percent of the time compared to the most-executed line, cov will decorate it with `cov-heavy-face`.
-- `cov-med-threshold` - If a line is run more than (`cov-med-threshold` * 100) percent of the time compared to the most-executed line, cov will decorate it with `cov-med-face`. This should be less than `cov-heavy-face`
-- `cov-coverage-mode` - If set, cov will ignore execution frequencies and simply decorate whether a line was executed. Executed lines are decorated with `cov-coverage-run-face`, while lines not-executed lines are decorated with `cov-coverage-not-run-face`
+- `cov-high-threshold` - If a line is run more than
+  (`cov-high-threshold` * 100) percent of the time compared to the
+  most-executed line, cov will decorate it with `cov-heavy-face`.
+- `cov-med-threshold` - If a line is run more than
+  (`cov-med-threshold` * 100) percent of the time compared to the
+  most-executed line, cov will decorate it with `cov-med-face`. This
+  should be less than `cov-heavy-face`
+- `cov-coverage-mode` - If set, cov will ignore execution frequencies
+  and simply decorate whether a line was executed. Executed lines are
+  decorated with `cov-coverage-run-face`, while lines not-executed
+  lines are decorated with `cov-coverage-not-run-face`
 
 ### Coverage File
-The coverage tool adds a postfix to the source file name to store the coverage data. For example, `gcov` adds `.gcov` to the file name. This postfix is the default that `gcov-mode` uses in order to locate the data.
-You can customize this default by setting the alist `gcov-coverage-alist`, which bind postixes the coverage tools:
+
+The coverage tool adds a postfix to the source file name to store the
+coverage data. For example, `gcov` adds `.gcov` to the file name. This
+postfix is the default that `gcov-mode` uses in order to locate the
+data. You can customize this default by setting the alist
+`gcov-coverage-alist`, which bind postixes the coverage tools:
+
 ```lisp
 (setq gcov-coverage-alist '((".gcov" . gcov)))
 ```
 
-If the coverage file is not stored in the same directory as the source file, the list `gcov-coverage-file-paths` can be set to contain additional paths, relative to the source path, to search. For example, with this configarion the current directory and the subdirectory `cov` will be used:
+If the coverage file is not stored in the same directory as the source
+file, the list `gcov-coverage-file-paths` can be set to contain
+additional paths, relative to the source path, to search. For example,
+with this configarion the current directory and the subdirectory `cov`
+will be used:
+
 ```lisp
 (setq gcov-coverage-file-paths '("." "cov")))
 ```
 
-To set the variable to project specific values, e.g. in `.dir-locals.el` file, you can make that variable buffer local by adding this to your init.el:
+To set the variable to project specific values, e.g. in
+`.dir-locals.el` file, you can make that variable buffer local by
+adding this to your init.el:
 
 ```lisp
 (make-variable-buffer-local 'gcov-coverage-file-paths)
 ```
 
-For more complex environments it is also possible to provide a function instead ot a path string. The function will be called with the path and name of the buffer file and should return a cons cell of the form (COV-FILE-PATH . COVERAGE-TOOL). PATH shall be the full path and name of the coverage data file. COVERAGE-TOOL shall specify the coverage tool.
+For more complex environments it is also possible to provide a
+function instead ot a path string. The function will be called with
+the path and name of the buffer file and should return a cons cell of
+the form (COV-FILE-PATH . COVERAGE-TOOL). PATH shall be the full path
+and name of the coverage data file. COVERAGE-TOOL shall specify the
+coverage tool.
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ coverage tool.
 
 ## Develop
 
+`cov.el` can be extended to understand more coverage formats. To add
+a new format:
+
+1. Add a function to `cov-coverage-file-paths` that locates a coverage
+   file for a given file. If a coverage file is found, it should
+   return a cons of the coverage file path and an identifier, like
+   `(cons filepath 'mytool)`
+2. Implement a `cov--mytool-parse`. The parse function is called with
+   a temp buffer with the coverage file data as `(current-buffer)` and
+   should parse the data and return the coverage as a alist of files
+   to coverage mapping. Coverage data is simply a list of two element
+   lists, where the first element is the line number and the second
+   the coverage count.
+
 ### Test
 Install dependencides:
 ```bash

--- a/cov.el
+++ b/cov.el
@@ -226,7 +226,7 @@ returned. Otherwise `cov--locate-coverage' is called."
   (or cov-coverage-file
       (setq cov-coverage-file (cov--locate-coverage (buffer-file-name)))))
 
-(defun cov--gcov-parse (buffer file-path)
+(defun cov--gcov-parse (file-path)
   "Parse a BUFFER containing gcov file, filter unused lines, and return a list of (LINE-NUM TIMES-RAN)."
   (let ((more t)
         ;; Derive the name of the covered file from the filename of
@@ -247,7 +247,7 @@ returned. Otherwise `cov--locate-coverage' is called."
         (setq more (= 0 (forward-line 1)))))
     (list (cons filename matches))))
 
-(defun cov--coveralls-parse (buffer file-path)
+(defun cov--coveralls-parse (file-path)
   "Parse a buffer containing coveralls file, filter unused lines, and return a list of (LINE-NUM TIMES-RAN)."
   (let*
       ((json-object-type 'hash-table)
@@ -269,7 +269,6 @@ returned. Otherwise `cov--locate-coverage' is called."
   (with-temp-buffer
     (insert-file-contents file-path)
     (funcall (intern (concat "cov--"  (symbol-name format) "-parse"))
-             (current-buffer)
              file-path)))
 
 (defun cov--make-overlay (line fringe help)

--- a/cov.el
+++ b/cov.el
@@ -36,7 +36,8 @@
 (require 'seq)
 
 (defgroup cov nil
-  "The group for everything in cov.el")
+  "The group for everything in cov.el"
+  :group 'tools)
 
 (defgroup cov-faces nil
   "Faces for cov."

--- a/cov.el
+++ b/cov.el
@@ -352,20 +352,28 @@ it if necessary, or reloading if the file has changed."
   (let ((cov (cov--coverage)))
     (when cov
       (let* ((file (car cov))
-             (stored-data (gethash file cov-coverages)))
+             (stored-data (gethash file cov-coverages))
+             (buffers))
         ;; File mtime changed, reload.
         (when (and stored-data (not (equal (car stored-data)
                                            (nth 5 (file-attributes file)))))
+          ;; Save the list of buffers that use this coverage, it's added again below.
+          (setq buffers (nth 1 stored-data))
           (message "Reloading coverage file.")
           (setq stored-data nil))
         ;; Coverage not loaded.
         (unless stored-data
           (setq stored-data (list (nth 5 (file-attributes file))
+                                  buffers
                                   (cov--read-and-parse file (cdr cov))))
           (puthash file stored-data cov-coverages))
+        ;; Register current buffer as user of this coverage.
+        (if (nth 1 stored-data)
+            (push (current-buffer) (nth 1 stored-data))
+          (setf (nth 1 stored-data) (list (current-buffer))))
         ;; Find file coverage.
         (let ((common (f-common-parent (list file (buffer-file-name)))))
-          (cdr (assoc (string-remove-prefix common (buffer-file-name)) (nth 1 stored-data))))))))
+          (cdr (assoc (string-remove-prefix common (buffer-file-name)) (nth 2 stored-data))))))))
 
 (defun cov-set-overlays ()
   "Add cov overlays."

--- a/cov.el
+++ b/cov.el
@@ -226,12 +226,15 @@ returned. Otherwise `cov--locate-coverage' is called."
   (or cov-coverage-file
       (setq cov-coverage-file (cov--locate-coverage (buffer-file-name)))))
 
-(defun cov--gcov-parse (file-path)
-  "Parse a BUFFER containing gcov file, filter unused lines, and return a list of (LINE-NUM TIMES-RAN)."
+(defun cov--gcov-parse ()
+  "Parse gcov coverage.
+
+Parses `(current-buffer)' containing gcov file, filter unused
+lines, and return a list of (FILE . (LINE-NUM TIMES-RAN))."
   (let ((more t)
         ;; Derive the name of the covered file from the filename of
         ;; the coverage file.
-        (filename (file-name-sans-extension (f-filename file-path)))
+        (filename (file-name-sans-extension (f-filename cov-coverage-file)))
         matches)
     (save-match-data
       (while more
@@ -247,8 +250,11 @@ returned. Otherwise `cov--locate-coverage' is called."
         (setq more (= 0 (forward-line 1)))))
     (list (cons filename matches))))
 
-(defun cov--coveralls-parse (file-path)
-  "Parse a buffer containing coveralls file, filter unused lines, and return a list of (LINE-NUM TIMES-RAN)."
+(defun cov--coveralls-parse ()
+  "Parse coveralls coverage.
+
+Parse coveralls data in `(current-buffer)' and return a list
+of (FILE . (LINE-NUM TIMES-RAN))."
   (let*
       ((json-object-type 'hash-table)
        (json-array-type 'list)
@@ -268,8 +274,8 @@ returned. Otherwise `cov--locate-coverage' is called."
   "Read coverage file FILE-PATH in FORMAT into temp buffer and parse it using `cov--FORMAT-parse'."
   (with-temp-buffer
     (insert-file-contents file-path)
-    (funcall (intern (concat "cov--"  (symbol-name format) "-parse"))
-             file-path)))
+    (setq-local cov-coverage-file file-path)
+    (funcall (intern (concat "cov--"  (symbol-name format) "-parse")))))
 
 (defun cov--make-overlay (line fringe help)
   "Create an overlay for the LINE.

--- a/cov.el
+++ b/cov.el
@@ -28,6 +28,9 @@
 
 ;;; Commentary:
 
+;; This mode locates and parses multiple coverage formats and display
+;; coverage using fringe overlays.
+
 ;;; Code:
 
 (require 'f)
@@ -206,7 +209,7 @@ COVERAGE-TOOL). If no file is found nil is returned."
                  (funcall path-or-fun file-dir file-name)))
              cov-coverage-file-paths)))
 
-(defun cov--locate-coveralls (file-dir file-name)
+(defun cov--locate-coveralls (file-dir _file-name)
   "Locate coveralls coverage from FILE-DIR for FILE-NAME.
 
 Looks for a `coverage-final.json' file. Return nil it not found."

--- a/test/cov-test.el
+++ b/test/cov-test.el
@@ -7,48 +7,54 @@
   (with-temp-buffer
     (insert "        -:   22:        ")
     (goto-char 1)
+    (setq-local cov-coverage-file "test")
     (should (equal
-             (cov--gcov-parse (current-buffer) "test")
+             (cov--gcov-parse)
              '(("test"))))))
 
 (ert-deftest cov--gcov-parse--block-test ()
   (with-temp-buffer
     (insert "        1:   21-block  0")
     (goto-char 1)
+    (setq-local cov-coverage-file "test")
     (should (equal
-             (cov--gcov-parse (current-buffer) "test")
+             (cov--gcov-parse)
              '(("test"))))))
 
 (ert-deftest cov--gcov-parse--executed-test ()
   (with-temp-buffer
     (insert "        6:   24:        ")
     (goto-char 1)
+    (setq-local cov-coverage-file "test")
     (should (equal
-             (cov--gcov-parse (current-buffer) "test")
+             (cov--gcov-parse)
              '(("test" (24 6)))))))
 
 (ert-deftest cov--gcov-parse--big-value-test ()
   (with-temp-buffer
     (insert "999999999:99999:        ")
     (goto-char 1)
+    (setq-local cov-coverage-file "test")
     (should (equal
-             (cov--gcov-parse (current-buffer) "test")
+             (cov--gcov-parse)
              '(("test" (99999 999999999)))))))
 
 (ert-deftest cov--gcov-parse--multiline-test ()
   (with-temp-buffer
     (insert "        6:    1:\n       16:    2:\n       66:    3:")
     (goto-char 1)
+    (setq-local cov-coverage-file "test")
     (should (equal
-             (cov--gcov-parse (current-buffer) "test")
+             (cov--gcov-parse)
              '(("test" (3 66) (2 16) (1 6)))))))
 
 (ert-deftest cov--gcov-parse--not-executed-test ()
   (with-temp-buffer
     (insert "    #####:   24:        ")
     (goto-char 1)
+    (setq-local cov-coverage-file "test")
     (should (equal
-             (cov--gcov-parse (current-buffer) "test")
+             (cov--gcov-parse)
              '(("test" (24 0)))))))
 
 ;; cov--coveralls-parse
@@ -56,8 +62,9 @@
   (with-temp-buffer
     (insert "{\"source_files\":[{\"coverage\":[0,null,3,1,2,0,null],\"source\":\"not covered\nignored\ncovered thee times\ncovered once\ncovered twice\nnot covered either\nignored too\n\",\"name\":\"test\"}]}")
     (goto-char 1)
+    (setq-local cov-coverage-file "test")
     (should (equal
-             (cov--coveralls-parse (current-buffer) "test")
+             (cov--coveralls-parse)
              ;; The coverage is actually returned in reverse order.
              '(("test" (6 0) (5 2) (4 1) (3 3) (1 0)))))))
 

--- a/test/cov-test.el
+++ b/test/cov-test.el
@@ -71,6 +71,7 @@
 ;; cov--locate-coverage-postfix
 (ert-deftest cov--locate-coverage-postfix-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage-postfix path "test" "." ".gcov"))
          (expected (file-truename (format "%s/test.gcov" path))))
     (should (equal
@@ -79,6 +80,7 @@
 
 (ert-deftest cov--locate-coverage-postfix---subdir-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage-postfix path "test" "../test" ".gcov"))
          (expected (file-truename (format "%s/test.gcov" path))))
     (should (equal
@@ -87,6 +89,7 @@
 
 (ert-deftest cov--locate-coverage-postfix--wrong-subdir-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage-postfix path "test" "wrong-subdir" ".gcov")))
     (should (equal
              actual
@@ -94,6 +97,7 @@
 
 (ert-deftest cov--locate-coverage-postfix--wrong-postfix-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage-postfix path "test" "." ".wrong-postfix")))
     (should (equal
              actual
@@ -102,6 +106,7 @@
 ;; cov--locate-coverage-path
 (ert-deftest cov--locate-coverage-path-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage-path path "test" "."))
          (expected (cons (file-truename (format "%s/test.gcov" path)) 'gcov)))
     (should (equal
@@ -110,6 +115,7 @@
 
 (ert-deftest cov--locate-coverage-path---subdir-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage-path path "test" "../test"))
          (expected (cons (file-truename (format "%s/test.gcov" path)) 'gcov)))
     (should (equal
@@ -118,6 +124,7 @@
 
 (ert-deftest cov--locate-coverage-path--wrong-subdir-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage-path path "test" "wrong-subdir")))
     (should (equal
              actual
@@ -126,6 +133,7 @@
 ;; cov--locate-coverage
 (ert-deftest cov--locate-coverage-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage (format "%s/%s" path "test")))
          (expected (cons (file-truename (format "%s/test.gcov" path)) 'gcov)))
     (should (equal
@@ -134,6 +142,7 @@
 
 (ert-deftest cov--locate-coverage-wrong-file-test ()
   (let* ((path test-path)
+         (cov-coverage-file-paths '("."))
          (actual (cov--locate-coverage (format "%s/%s" path "wrong-file"))))
     (should (equal
              actual


### PR DESCRIPTION
Bit all over the place, this PR:

Cleaned up documentation strings, updated readme, simplified the parser interface (no need to pass the buffer as argument as it's already current, and supply the filename as a buffer local variable, as not all parsers need it), documented it, implemented a global storage og coverage, fixed coverage for files in sub-directories, implemented a simple file time check for reloading coverage when file changes and added updating of overlays in all buffers that used the reloaded coverage.

Now I just need to implement inotify watching of coverage files, and purging of unused coverage data, and we're in a pretty sweet spot. Maybe an `cov-mode-if-found` function so one can just add that to the mode-hook of supported languages. 