### PR TITLE
Update and repair gitub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,5 @@ jobs:
         wget 'https://raw.githubusercontent.com/flycheck/emacs-travis/master/emacs-travis.mk'
         make -f emacs-travis.mk install_cask
         cask install
-        cask exec ert-runner
+        GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} cask exec ert-runner
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     paths-ignore:
@@ -19,6 +20,7 @@ jobs:
           - 26.1
           - 26.2
           - 26.3
+          - 27.1
           - snapshot
     steps:
     - uses: purcell/setup-emacs@master
@@ -33,4 +35,5 @@ jobs:
         make -f emacs-travis.mk install_cask
         cask install
         GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} cask exec ert-runner
+      shell: bash -ev {0}
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -6,4 +6,6 @@
 (when (require 'undercover nil t)
   ;; Track coverage, but don't send to coveralls (Travis will send it
   ;; to Codecov).
-  (undercover "*.el" (:report-type :codecov)))
+  (undercover "*.el"
+              (:report-format 'codecov)
+              (:send-report nil)))


### PR DESCRIPTION
An update of undercover has broken it's use in this package.
Fix that, add Emacs 27.1 as a tested Emacs version and some other small things.