### PR TITLE
Fix cov--lcov-parser so it no longer signals errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         emacs_version:
@@ -23,7 +24,10 @@ jobs:
           - 27.1
           - 27.2
           - 28.1
-          - snapshot
+        experimental: [false]
+        include:
+          - emacs_version: snapshot
+            experimental: true
     steps:
     - uses: purcell/setup-emacs@master
       with:

--- a/cov.el
+++ b/cov.el
@@ -402,14 +402,18 @@ Return a list `((FILE . ((LINE-NUM EXEC-COUNT) ...)) ...)'."
                               (or (gethash sourcefile data)
                                   (puthash sourcefile (make-hash-table :test 'eql) data)))))
                 ;; DA:<line-num>,<exec-count>[,...]
-                ("DA" (if (looking-at (rx (group-n 1 (1+ digit)) ?,
+                ("DA"
+                 (if filelines
+                     (if (looking-at (rx (group-n 1 (1+ digit)) ?,
                                           (group-n 2 (1+ digit))
                                           (optional ?, (group (* any)))))
                           (let ((lineno (string-to-number (match-string 1)))
                                 (count (string-to-number (match-string 2))))
                             (puthash lineno (+ (gethash lineno filelines 0) count) filelines))
                         (error "`lcov' parse error, bad DA line %s:%d"
-                               cov-coverage-file (line-number-at-pos (point)))))
+                               cov-coverage-file (line-number-at-pos (point))))
+                   (error "`lcov' parse error, DA line %s:%d without preceeding SF"
+                          cov-coverage-file (line-number-at-pos (point)))))
                 ;; End of coverage data for a source file, push
                 ;; current file information to `data'
                 ("end_of_record" (setq sourcefile nil filelines nil)))

--- a/cov.el
+++ b/cov.el
@@ -383,24 +383,24 @@ Return a list `((FILE . ((LINE-NUM EXEC-COUNT) ...)) ...)'."
             (widen)
             (goto-char (point-min))
             (while (not (eobp))
-              (unless (looking-at cov--lcov-prefix-re)
+              (if (looking-at cov--lcov-prefix-re)
+                  (goto-char (match-end 0))
                 (error "Unable to parse lcov data from %s: %s"
                        cov-coverage-file
                        (buffer-substring (line-beginning-position) (line-end-position))))
-              (goto-char (match-end 0))
               (pcase (match-string 1)
                 ;; Each SF signals the start of a new SourceFile.
                 ("SF" (if (or sourcefile filelines)
                           (error "`lcov' parse error, SF with no preceeding end_of_record %s:%d"
-                                 cov-coverage-file (line-number-at-pos (point)))
-                        ;; SF always hold an absolute path
-                        (setq sourcefile (file-truename
-                                          (expand-file-name
-                                           (buffer-substring (point) (line-end-position))
-                                           (file-name-directory cov-coverage-file))))
-                        (setq filelines
-                              (or (gethash sourcefile data)
-                                  (puthash sourcefile (make-hash-table :test 'eql) data)))))
+                                 cov-coverage-file (line-number-at-pos (point))))
+                 ;; SF always hold an absolute path
+                 (setq sourcefile (file-truename
+                                   (expand-file-name
+                                    (buffer-substring (point) (line-end-position))
+                                    (file-name-directory cov-coverage-file))))
+                 (setq filelines
+                       (or (gethash sourcefile data)
+                           (puthash sourcefile (make-hash-table :test 'eql) data))))
                 ;; DA:<line-num>,<exec-count>[,...]
                 ("DA"
                  (if filelines

--- a/cov.el
+++ b/cov.el
@@ -369,6 +369,11 @@ valid lcov data, nil otherwise."
               (cl-return-from cov--lcov-file-p nil))
             (forward-line)))))))
 
+(defun cov--warning (string &rest args)
+  "Display a `cov' warning.
+Create the message by passing STRING and ARGS to `format'."
+  (display-warning 'cov (apply #'format string args)))
+
 (defun cov--lcov-parse (&optional buffer)
   "Parse lcov trace file in BUFFER.
 Read from `current-buffer' if BUFFER is nil.


### PR DESCRIPTION
As discussed in #45 it is probably best not to use error in code that is called directly from a minor mode.
This change should allow slightly broken `lcov` files to still generate somewhat correct results.

As reported in Sigma/mocker.el#10 , `mocker.el` is affected by [Emacs bug 56596](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=56596), so I also marked the snapshot job as ok-to-fail.