### PR TITLE
Allow setting a custom root for a lcov project

### DIFF
--- a/cov.el
+++ b/cov.el
@@ -235,6 +235,11 @@ thean one file, the first value will be returned.")
 There is no standard basename for lcov tracefiles. Set
 `cov-lcov-file-name' locally for the project.")
 
+(defvar cov-lcov-project-root nil
+  "Define the root directory for which to construct the relative paths used
+  inside the lcov file. Useful when the lcov file is not located in the root of
+  the project.")
+
 (defun cov--check-pattern (pattern file-dir file-name)
   "Check if a PATTERN match a coverage file from FILE-DIR for FILE-NAME.
 If PATTERN is a function return (funcall PATTERN FILE-DIR
@@ -399,11 +404,12 @@ Return a list `((FILE . ((LINE-NUM EXEC-COUNT) ...)) ...)'."
                           (cov--warning
                            "`lcov' parse error, SF with no preceeding end_of_record %s:%d"
                            cov-coverage-file (line-number-at-pos))
-                        ;; SF always hold an absolute path
                         (setq sourcefile (file-truename
                                           (expand-file-name
                                            (buffer-substring (point) (line-end-position))
-                                           (file-name-directory cov-coverage-file))))
+                                           (or cov-lcov-project-root
+                                               (file-name-directory cov-coverage-file)))))
+                        (message (concat "sourcefile: " sourcefile))
                         (setq filelines
                               (or (gethash sourcefile data)
                                   (puthash sourcefile (make-hash-table :test 'eql) data)))))


### PR DESCRIPTION
Hi, 

I'm using [Jest](https://jestjs.io) in my projects and the generated lcov file contains relative paths to the tested files. The problem is that the lcov file is located under `<project>/test-results/lcov.info`, but the paths are relative to the project root directory instead of the lcov file itself.

With my current changes, I can use the following locator function and everything works as expected:

```elisp
  (defun cov--locate-jest-lcov (file-dir file-name)
    (and-let* ((jest-root (projectile-locate-dominating-file file-dir "jest.config.js"))
               (lcov-file (f-join jest-root "test-results/lcov.info"))
               ((file-exists-p lcov-file)))
      (setq cov-lcov-project-root jest-root)
      (cons lcov-file 'lcov)))

  (add-to-list 'cov-coverage-file-paths #'cov--locate-jest-lcov)
```

I don't think the locator function should be added to the PR as the amount of variance to setup Jest is too big, but would you be open to the inclusion `cov-lcov-project-root`?