### PR TITLE
Gracefully handle empty coverage.json

### DIFF
--- a/cov.el
+++ b/cov.el
@@ -514,19 +514,21 @@ Project coveragepy is released at <https://github.com/nedbat/coveragepy/>."
   (let*
       ((json-object-type 'hash-table)
        (json-array-type 'list)
-       (coverage (json-read))
+       (coverage (condition-case nil (json-parse-string (buffer-string))
+                   (json-end-of-file nil)))
        (matches (list)))
-    (maphash (lambda (filename file-value)
-               (push (cons (file-truename
-                            (expand-file-name filename
-                                              (file-name-directory cov-coverage-file)))
-                           (append
-                            (mapcar (lambda (line) (list line 1))
-                                    (gethash "executed_lines" file-value))
-                            (mapcar (lambda (line) (list line 0))
-                                    (gethash "missing_lines" file-value))))
-                     matches))
-             (gethash "files" coverage))
+    (when coverage
+      (maphash (lambda (filename file-value)
+                (push (cons (file-truename
+                             (expand-file-name filename
+                                               (file-name-directory cov-coverage-file)))
+                            (append
+                             (mapcar (lambda (line) (list line 1))
+                                     (gethash "executed_lines" file-value))
+                             (mapcar (lambda (line) (list line 0))
+                                     (gethash "missing_lines" file-value))))
+                      matches))
+              (gethash "files" coverage)))
     matches))
 
 (defun cov--read-and-parse (file-path format)
@@ -667,19 +669,21 @@ Won't update `(current-buffer)' if IGNORE-CURRENT is non-nil."
     (cov--message "Reloading coverage file %s." file)
     (setf (cov-data-coverage coverage) nil))
   (unless (cov-data-coverage coverage)
-    (setf (cov-data-coverage coverage) (cov--read-and-parse file (cov-data-type coverage)))
-    (cl-loop for (srcfile . src-cov-data) in (cov-data-coverage coverage)
-             do (cl-assert (string= srcfile (file-truename srcfile))
-                           "Source files must be truenames"))
-    (setf (cov-data-mtime coverage) (cov--file-mtime file))
-    ;; Update buffers using this coverage.
-    (let ((buffers (cov-data-buffers coverage)))
-      (when ignore-current
-        (setq buffers (remove (current-buffer) buffers)))
-      (dolist (buffer buffers)
-        (with-current-buffer buffer
-          (cov--message "Updating coverage for \"%s\"" (buffer-name buffer))
-          (cov-update))))))
+    (let ((new-coverage (cov--read-and-parse file (cov-data-type coverage))))
+      (setf (cov-data-coverage coverage) new-coverage)
+      (cl-loop for (srcfile . src-cov-data) in (cov-data-coverage coverage)
+               do (cl-assert (string= srcfile (file-truename srcfile))
+                             "Source files must be truenames"))
+      (setf (cov-data-mtime coverage) (cov--file-mtime file))
+      ;; Update buffers using this coverage
+      (when new-coverage
+        (let ((buffers (cov-data-buffers coverage)))
+         (when ignore-current
+           (setq buffers (remove (current-buffer) buffers)))
+         (dolist (buffer buffers)
+           (with-current-buffer buffer
+             (cov--message "Updating coverage for \"%s\"" (buffer-name buffer))
+             (cov-update))))))))
 
 (defun cov-kill-buffer-hook ()
   "Unregister buffer with coverage data and clean out unused coverage."

--- a/cov.el
+++ b/cov.el
@@ -656,8 +656,9 @@ it if necessary, or reloading if the file has changed."
 
         (add-hook 'kill-buffer-hook 'cov-kill-buffer-hook nil t)
         ;; Find file coverage.
-        (cdr (assoc (file-truename (buffer-file-name))
-                    (cov-data-coverage stored-data)))))))
+        (when (buffer-file-name)
+          (cdr (assoc (file-truename (buffer-file-name))
+                      (cov-data-coverage stored-data))))))))
 
 (defun cov--load-coverage (coverage file &rest ignore-current)
   "Load coverage data into COVERAGE from FILE.

--- a/test/cov-test.el
+++ b/test/cov-test.el
@@ -945,6 +945,23 @@ text properties with list values."
       (dolist (overlay cov-overlays)
         (should (equal (overlay-get overlay 'help-echo) (pop expected)))))))
 
+(ert-deftest cov-mode--coveragepy-empty-source-nil ()
+  (cov--with-test-buffer "coveragepy/empty/foo.py"
+    (cov-mode 0)
+    (cov-mode 1)
+
+    ; should not fail
+    (cov--get-buffer-coverage)))
+
+(ert-deftest cov-mode--coveragepy-empty-source-neighbor-buffer-no-recusion ()
+  (cov--with-test-buffer "coveragepy/empty/foo.py"
+    (cov-mode 0)
+    (cov-mode 1)
+    (cov--with-test-buffer "coveragepy/empty/bar.py"
+
+      ; should not end up in infinite recursion
+      (cov-update))))
+
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; End:

--- a/test/cov-test.el
+++ b/test/cov-test.el
@@ -945,13 +945,25 @@ text properties with list values."
       (dolist (overlay cov-overlays)
         (should (equal (overlay-get overlay 'help-echo) (pop expected)))))))
 
-(ert-deftest cov-mode--coveragepy-empty-source-nil ()
+(ert-deftest cov-mode--coveragepy-empty-source-file-buffer ()
   (cov--with-test-buffer "coveragepy/empty/foo.py"
     (cov-mode 0)
     (cov-mode 1)
 
     ; should not fail
     (cov--get-buffer-coverage)))
+
+; this is triggered when opening magit-diff buffers
+(ert-deftest cov-mode--coveragepy-empty-source-no-file-buffer ()
+  (cov--with-test-buffer "coveragepy/empty/foo.py"
+    (cov-mode 0)
+    (cov-mode 1)
+    (let ((file-path (concat default-directory "test/coveragepy/empty/foo.py")))
+      (with-temp-buffer
+       (mocker-let ((buffer-file-name () ((:output file-path))))
+         (cov-turn-on))
+       ; should not fail
+       (cov--get-buffer-coverage)))))
 
 (ert-deftest cov-mode--coveragepy-empty-source-neighbor-buffer-no-recusion ()
   (cov--with-test-buffer "coveragepy/empty/foo.py"

--- a/test/coveragepy/empty/bar.py
+++ b/test/coveragepy/empty/bar.py
@@ -1,0 +1,2 @@
+def bar():
+    print("bar")

--- a/test/coveragepy/empty/foo.py
+++ b/test/coveragepy/empty/foo.py
@@ -1,0 +1,2 @@
+def foo():
+    print("foo")


### PR DESCRIPTION
When using pytest with `coverage.json` it happens with every pytest run that the coverage source file `coverage.json` for a split of a second is empty. That leads to annoying errors, each time a pytest session is performed as `cov-watch-callback` is quick enough to catch the empty `coverage.json`.

This PR addresses the issue by handling an empty `coverage.json` gracefully.